### PR TITLE
Fix incorrect display index for remote desktops

### DIFF
--- a/source/vistas/ui/windows/main.py
+++ b/source/vistas/ui/windows/main.py
@@ -214,7 +214,7 @@ class MainWindow(wx.Frame):
         if state.get('display_index') is not None:
             try:
                 display_area = wx.Display(state['display_index']).GetClientArea()
-            except:
+            except AssertionError:
                 display_area = wx.Display(0).GetClientArea()
         else:
             display_area = wx.Display(0).GetClientArea()

--- a/source/vistas/ui/windows/main.py
+++ b/source/vistas/ui/windows/main.py
@@ -212,7 +212,10 @@ class MainWindow(wx.Frame):
 
     def LoadState(self, state):
         if state.get('display_index') is not None:
-            display_area = wx.Display(state['display_index']).GetClientArea()
+            try:
+                display_area = wx.Display(state['display_index']).GetClientArea()
+            except:
+                display_area = wx.Display(0).GetClientArea()
         else:
             display_area = wx.Display(0).GetClientArea()
 


### PR DESCRIPTION
Fixes a crash on startup for when preferences has saved a display index that is not possible to display in remote desktop. This happens when a user has multiple displays, shows the application in any display that is not the 0th display, exits the application, and then remotes into that desktop.