### PR TITLE
Core profile fixes

### DIFF
--- a/source/vistas/core/graphics/mesh_renderable.py
+++ b/source/vistas/core/graphics/mesh_renderable.py
@@ -59,12 +59,14 @@ class MeshRenderable(Renderable):
 
         shader.pre_render(camera)
         glUniform4f(shader.get_uniform_location('color'), r, g, b, 1.0)
+        glBindVertexArray(self.mesh.vertex_array_object)
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, self.mesh.index_buffer)
 
         glDrawElements(self.mesh.mode, self.mesh.num_indices, GL_UNSIGNED_INT, None)
 
-        shader.post_render(camera)
+        glBindVertexArray(0)
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)
+        shader.post_render(camera)
 
     def aqcuire_texture(self, texture):
         self.textures_map[texture.number] = texture

--- a/source/vistas/core/graphics/mesh_renderable.py
+++ b/source/vistas/core/graphics/mesh_renderable.py
@@ -13,7 +13,7 @@ class MeshRenderable(Renderable):
 
         self._mesh = None
         self.textures_map = {}
-        self.bounding_box = None
+        self._bounding_box = None
         self.mesh = Mesh() if mesh is None else mesh
 
     @property

--- a/source/vistas/core/graphics/mesh_renderable.py
+++ b/source/vistas/core/graphics/mesh_renderable.py
@@ -13,7 +13,6 @@ class MeshRenderable(Renderable):
 
         self._mesh = None
         self.textures_map = {}
-        self._bounding_box = None
         self.mesh = Mesh() if mesh is None else mesh
 
     @property
@@ -56,17 +55,14 @@ class MeshRenderable(Renderable):
             return
 
         shader = self.selection_shader
-
         shader.pre_render(camera)
         glUniform4f(shader.get_uniform_location('color'), r, g, b, 1.0)
-        glBindVertexArray(self.mesh.vertex_array_object)
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, self.mesh.index_buffer)
 
         glDrawElements(self.mesh.mode, self.mesh.num_indices, GL_UNSIGNED_INT, None)
 
-        glBindVertexArray(0)
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)
         shader.post_render(camera)
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)
 
     def aqcuire_texture(self, texture):
         self.textures_map[texture.number] = texture

--- a/source/vistas/core/graphics/renderable.py
+++ b/source/vistas/core/graphics/renderable.py
@@ -45,18 +45,18 @@ class Renderable:
         self.rotation = Vector3()
         self._bounding_box = None
 
-        self.bbox_vao = -1
-        self.bbox_vertex_buffer = -1
-        self.bbox_index_buffer = -1
+        self.bbox_vao = None
+        self.bbox_vertex_buffer = None
+        self.bbox_index_buffer = None
 
         # Init the VAO
         self.bounding_box = BoundingBox(0, 0, 0, 0, 0, 0)
 
     def __del__(self):
         if self.bbox_vao != -1:
-            glDeleteVertexArrays(1, [self.bbox_vao])
-            glDeleteBuffers(1, [self.bbox_vertex_buffer])
-            glDeleteBuffers(1, [self.bbox_index_buffer])
+            glDeleteVertexArrays(1, self.bbox_vao)
+            glDeleteBuffers(1, self.bbox_vertex_buffer)
+            glDeleteBuffers(1, self.bbox_index_buffer)
 
     @property
     def bounding_box(self):
@@ -89,7 +89,7 @@ class Renderable:
         ], dtype=GLfloat)
 
         # Init bbox VAO if need be
-        if self.bbox_vao == -1:
+        if self.bbox_vao is None:
             self.bbox_vao = glGenVertexArrays(1)
             self.bbox_vertex_buffer = glGenBuffers(1)
             self.bbox_index_buffer = glGenBuffers(1)
@@ -119,7 +119,9 @@ class Renderable:
         self.bbox_shader_program.uniform3fv("color", 1, color.rgb.rgb_list)
         glBindVertexArray(self.bbox_vao)
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, self.bbox_index_buffer)
+
         glDrawElements(GL_LINES, 24, GL_UNSIGNED_INT, None)
+
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)
         glBindVertexArray(0)
         self.bbox_shader_program.post_render(camera)

--- a/source/vistas/core/graphics/renderable.py
+++ b/source/vistas/core/graphics/renderable.py
@@ -43,12 +43,28 @@ class Renderable:
         self.scale = Vector3([1, 1, 1])
         self.position = Vector3()
         self.rotation = Vector3()
+        self._bounding_box = None
+
+        self.bbox_vao = -1
+        self.bbox_vertex_buffer = -1
+        self.bbox_index_buffer = -1
+
+        # Init the VAO
         self.bounding_box = BoundingBox(0, 0, 0, 0, 0, 0)
 
-    def render(self, camera):
-        pass
+    def __del__(self):
+        if self.bbox_vao != -1:
+            glDeleteVertexArrays(1, [self.bbox_vao])
+            glDeleteBuffers(1, [self.bbox_vertex_buffer])
+            glDeleteBuffers(1, [self.bbox_index_buffer])
 
-    def render_bounding_box(self, color, camera):
+    @property
+    def bounding_box(self):
+        return self._bounding_box
+
+    @bounding_box.setter
+    def bounding_box(self, bounding_box):
+        self._bounding_box = bounding_box
 
         bbox_scale = 0.1
         x_margin = (self.bounding_box.max_x - self.bounding_box.min_x) * bbox_scale
@@ -72,34 +88,41 @@ class Renderable:
             x_max, y_max, z_max     # 7
         ], dtype=GLfloat)
 
-        # Start render pipeline
-        self.bbox_shader_program.pre_render(camera)
-        self.bbox_shader_program.uniform3fv("color", 1, color.rgb.rgb_list)
+        # Init bbox VAO if need be
+        if self.bbox_vao == -1:
+            self.bbox_vao = glGenVertexArrays(1)
+            self.bbox_vertex_buffer = glGenBuffers(1)
+            self.bbox_index_buffer = glGenBuffers(1)
 
-        # Now setup buffers specific to this bbox
-        vertex_buffer = glGenBuffers(1)
-        glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer)
+            # One-time bind of index buffer
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, self.bbox_index_buffer)
+            glBufferData(GL_ELEMENT_ARRAY_BUFFER, self.bbox_indices.nbytes, self.bbox_indices, GL_STATIC_DRAW)
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)
+
+        # Update VAO
+        glBindVertexArray(self.bbox_vao)
+        glBindBuffer(GL_ARRAY_BUFFER, self.bbox_vertex_buffer)
         glBufferData(GL_ARRAY_BUFFER, vertices.nbytes, vertices, GL_STATIC_DRAW)
+
         position_loc = self.bbox_shader_program.get_attrib_location("position")
         glEnableVertexAttribArray(position_loc)
         glVertexAttribPointer(position_loc, 3, GL_FLOAT, GL_FALSE, 0, None)
 
-        index_buffer = glGenBuffers(1)
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buffer)
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, self.bbox_indices.nbytes, self.bbox_indices, GL_STATIC_DRAW)
-
-        # Render
-        glDrawElements(GL_LINES, 24, GL_UNSIGNED_INT, None)
-
-        # Unlink the shader program
-        glDisableVertexAttribArray(position_loc)
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)
         glBindBuffer(GL_ARRAY_BUFFER, 0)
-        self.bbox_shader_program.post_render(camera)
+        glBindVertexArray(0)
 
-        # Now teardown this program's buffers
-        glDeleteBuffers(1, [vertex_buffer])
-        glDeleteBuffers(1, [index_buffer])
+    def render(self, camera):
+        pass
+
+    def render_bounding_box(self, color, camera):
+        self.bbox_shader_program.pre_render(camera)
+        self.bbox_shader_program.uniform3fv("color", 1, color.rgb.rgb_list)
+        glBindVertexArray(self.bbox_vao)
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, self.bbox_index_buffer)
+        glDrawElements(GL_LINES, 24, GL_UNSIGNED_INT, None)
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)
+        glBindVertexArray(0)
+        self.bbox_shader_program.post_render(camera)
 
     def render_for_selection_hit(self, camera, r, g, b):
         pass


### PR DESCRIPTION
This PR addresses some discrepancies with using OpenGL core profile (3.3+). Since we're supporting macOS builds, we have to use Vertex Array Objects whenever we perform rendering. This PR addresses #35.