### PR TITLE
Bounding box vao now deletes properly

### DIFF
--- a/source/vistas/core/graphics/mesh_renderable.py
+++ b/source/vistas/core/graphics/mesh_renderable.py
@@ -15,6 +15,9 @@ class MeshRenderable(Renderable):
         self.textures_map = {}
         self.mesh = Mesh() if mesh is None else mesh
 
+    def __del__(self):
+        self._mesh = None
+
     @property
     def mesh(self):
         return self._mesh

--- a/source/vistas/core/graphics/renderable.py
+++ b/source/vistas/core/graphics/renderable.py
@@ -53,7 +53,7 @@ class Renderable:
         self.bounding_box = BoundingBox(0, 0, 0, 0, 0, 0)
 
     def __del__(self):
-        if self.bbox_vao != -1:
+        if self.bbox_vao is not None:
             glDeleteVertexArrays(1, self.bbox_vao)
             glDeleteBuffers(1, self.bbox_vertex_buffer)
             glDeleteBuffers(1, self.bbox_index_buffer)


### PR DESCRIPTION
Minor bug fix. Bounding box vertex array objects were not deleting properly when an instance of a `MeshRenderable` was deleted.