### PR TITLE
Load project from command line

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -1,6 +1,9 @@
 import platform
 import sys
+
 import matplotlib
+
+from vistas.ui.app import App
 
 if platform.uname().system == 'Windows':
     matplotlib.use('AGG')
@@ -12,6 +15,5 @@ if len(sys.argv) > 1:
 
 # Main app
 else:
-    from vistas.ui.app import App
     app = App.get()
     app.MainLoop()

--- a/source/main.py
+++ b/source/main.py
@@ -13,7 +13,5 @@ if len(sys.argv) > 1:
 # Main app
 else:
     from vistas.ui.app import App
-    import os
-    print(os.getcwd())
     app = App.get()
     app.MainLoop()

--- a/source/main.py
+++ b/source/main.py
@@ -1,11 +1,19 @@
 import platform
-
+import sys
 import matplotlib
 
 if platform.uname().system == 'Windows':
     matplotlib.use('AGG')
 
-from vistas.ui.app import App
+# Check for command line arguments
+if len(sys.argv) > 1:
+    from vistas.cli.main import cli
+    cli()
 
-app = App.get()
-app.MainLoop()
+# Main app
+else:
+    from vistas.ui.app import App
+    import os
+    print(os.getcwd())
+    app = App.get()
+    app.MainLoop()

--- a/source/vistas/cli/__init__.py
+++ b/source/vistas/cli/__init__.py
@@ -1,0 +1,6 @@
+import click
+
+
+@click.group(help="Command line interface for pyvistas")
+def cli():
+    pass

--- a/source/vistas/cli/load_from_file.py
+++ b/source/vistas/cli/load_from_file.py
@@ -1,0 +1,12 @@
+import click
+from vistas.cli import cli
+from vistas.ui.app import App
+import os
+
+
+@cli.command(short_help='Start VISTAS with a predefined project loaded.')
+@click.argument('project', type=click.Path(exists=True))
+def load_from_file(project):
+    os.chdir(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))  # Todo - macOS equivalent?
+    App.preload_save = project
+    App.get().MainLoop()

--- a/source/vistas/cli/main.py
+++ b/source/vistas/cli/main.py
@@ -1,4 +1,2 @@
 from vistas.cli import cli
-
-from vistas.cli.export_webgl import export_webgl
-from vistas.cli.load_from_file import load_from_file
+from vistas.cli.startup_project import startup_project

--- a/source/vistas/cli/main.py
+++ b/source/vistas/cli/main.py
@@ -1,0 +1,4 @@
+from vistas.cli import cli
+
+from vistas.cli.export_webgl import export_webgl
+from vistas.cli.load_from_file import load_from_file

--- a/source/vistas/cli/startup_project.py
+++ b/source/vistas/cli/startup_project.py
@@ -6,7 +6,7 @@ import os
 
 @cli.command(short_help='Start VISTAS with a predefined project loaded.')
 @click.argument('project', type=click.Path(exists=True))
-def load_from_file(project):
+def startup_project(project):
     os.chdir(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))  # Todo - macOS equivalent?
-    App.preload_save = project
+    App.startup_project = project
     App.get().MainLoop()

--- a/source/vistas/cli/startup_project.py
+++ b/source/vistas/cli/startup_project.py
@@ -7,6 +7,9 @@ import os
 @cli.command(short_help='Start VISTAS with a predefined project loaded.')
 @click.argument('project', type=click.Path(exists=True))
 def startup_project(project):
-    os.chdir(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))  # Todo - macOS equivalent?
+    source_dir = os.path.abspath(__file__)
+    for _ in range(3):  # Move working directory up 3 directories to allow App to detect builtin plugins
+        source_dir = os.path.dirname(source_dir)
+    os.chdir(source_dir)
     App.startup_project = project
     App.get().MainLoop()

--- a/source/vistas/ui/app.py
+++ b/source/vistas/ui/app.py
@@ -26,7 +26,7 @@ HandleExceptionEvent, EVT_HANDLE_EXCEPTION = wx.lib.newevent.NewEvent()
 class App(wx.App):
     """ The top-level UI application. """
     _global_app = None
-    preload_save = None
+    startup_project = None
     init = False
 
     @classmethod
@@ -90,7 +90,7 @@ class App(wx.App):
         else:
             asyncio.set_event_loop(asyncio.SelectorEventLoop())
 
-        self.app_controller = AppController(self.preload_save)
+        self.app_controller = AppController(self.startup_project)
 
         # Download FFmpeg
         DownloadFFMpegThread().start()

--- a/source/vistas/ui/app.py
+++ b/source/vistas/ui/app.py
@@ -26,6 +26,7 @@ HandleExceptionEvent, EVT_HANDLE_EXCEPTION = wx.lib.newevent.NewEvent()
 class App(wx.App):
     """ The top-level UI application. """
     _global_app = None
+    preload_save = None
     init = False
 
     @classmethod
@@ -89,7 +90,7 @@ class App(wx.App):
         else:
             asyncio.set_event_loop(asyncio.SelectorEventLoop())
 
-        self.app_controller = AppController()
+        self.app_controller = AppController(self.preload_save)
 
         # Download FFmpeg
         DownloadFFMpegThread().start()

--- a/source/vistas/ui/controllers/app.py
+++ b/source/vistas/ui/controllers/app.py
@@ -23,9 +23,11 @@ PADDING = 5
 
 
 class AppController(wx.EvtHandler):
-    def __init__(self):
+    def __init__(self, load_from_file=None):
         super().__init__()
         load_plugins(paths.get_builtin_plugins_directory())
+
+        self.commandline_save = load_from_file
 
         self.main_window = MainWindow(None, wx.ID_ANY)
         self.main_window.Show()
@@ -83,6 +85,10 @@ class AppController(wx.EvtHandler):
         wx.adv.SplashScreen(
             splash_composite, wx.adv.SPLASH_TIMEOUT | wx.adv.SPLASH_CENTRE_ON_PARENT, 5000, self.main_window, wx.ID_ANY
         )
+
+        if self.commandline_save:
+            self.main_window.project_controller.LoadProject(self.commandline_save)
+            self.commandline_save = None
 
     def OnWindowMenu(self, event):
         event_id = event.GetId()

--- a/source/vistas/ui/controllers/app.py
+++ b/source/vistas/ui/controllers/app.py
@@ -23,11 +23,11 @@ PADDING = 5
 
 
 class AppController(wx.EvtHandler):
-    def __init__(self, load_from_file=None):
+    def __init__(self, startup_project=None):
         super().__init__()
         load_plugins(paths.get_builtin_plugins_directory())
 
-        self.commandline_save = load_from_file
+        self.startup_project = startup_project
 
         self.main_window = MainWindow(None, wx.ID_ANY)
         self.main_window.Show()
@@ -86,9 +86,9 @@ class AppController(wx.EvtHandler):
             splash_composite, wx.adv.SPLASH_TIMEOUT | wx.adv.SPLASH_CENTRE_ON_PARENT, 5000, self.main_window, wx.ID_ANY
         )
 
-        if self.commandline_save:
-            self.main_window.project_controller.LoadProject(self.commandline_save)
-            self.commandline_save = None
+        if self.startup_project:
+            self.main_window.project_controller.LoadProject(self.startup_project)
+            self.startup_project = None
 
     def OnWindowMenu(self, event):
         event_id = event.GetId()


### PR DESCRIPTION
This PR adds a simple command line interface for loading VISTAS saves from the command line. Mainly useful for development, but could also allow for using other command line utilities.


```
# Usage
python main.py startup_project <path/to/save.vistas>

# Example
python main.py startup_project C:\Users\<user>\Documents\pyvistas_testdata\ChesapeakeBay\startup_test.vistas
```

Todo:
- [ ] Test on macOS